### PR TITLE
Setup robustness

### DIFF
--- a/custom_components/hildebrandglow_dcc/const.py
+++ b/custom_components/hildebrandglow_dcc/const.py
@@ -1,3 +1,13 @@
 """Constants for the Hildebrand Glow (DCC) integration."""
 
 DOMAIN = "hildebrandglow_dcc"
+
+# Virtual Entity Classifiers
+ELEC_CONSUMPTION_CLASSIFIER = "electricity.consumption"
+GAS_CONSUMPTION_CLASSIFIER = "gas.consumption"
+ELEC_COST_CLASSIFIER = "electricity.consumption.cost"
+GAS_COST_CLASSIFIER = "gas.consumption.cost"
+
+# Device Types
+ELECTRIC_METER = "electric_meter"
+GAS_METER = "gas_meter"

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pyglowmarkt==0.5.6"
   ],
-  "version": "1.1.0"
+  "version": "1.1.5"
 }

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -29,6 +29,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(minutes=15)
+TARIFF_SCAN_INTERVAL = timedelta(minutes=60)
 
 # --- COORDINATOR CLASSES ---
 
@@ -83,9 +84,7 @@ class TariffCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"Tariff Data {resource.classifier}",  # More specific name for logging
-            update_interval=timedelta(
-                minutes=60
-            ),  # Or your desired tariff update interval
+            update_interval=TARIFF_SCAN_INTERVAL,
         )
         self.resource = resource
 


### PR DESCRIPTION
I have created a branch (tentatively called v1.1.5 when released) that has a more robust setup when the integration starts.

It (deliberately) creates the hub and sensors, and reports that as success (or failure) once loaded - so for folks who werent seeing sensors (because one of them failed in attempting to grab the data) - this wont happen anymore.

It does mean that the sensors will be listed in the Integration page, as soon as authentication and setup is successful - but they will be immediately 'unavailable' until the data is successfully pulled, and HA considers the sensor 'stable'.  Typically two pull cycles - ie 30 mins.
Note the rate and standing tarrifs are every hour - and by default are switched off (as per the original integration). so will be unavailable for longer if they are enabled and configured by your energy provider(s).