### PR TITLE
Add device/state class for rates & standing charge to keep long term history

### DIFF
--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -370,6 +370,7 @@ class Standing(CoordinatorEntity, SensorEntity):
     """An entity using CoordinatorEntity."""
 
     _attr_device_class = SensorDeviceClass.MONETARY
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_has_entity_name = True
     _attr_name = "Standing charge"
     _attr_native_unit_of_measurement = "GBP"
@@ -413,7 +414,8 @@ class Standing(CoordinatorEntity, SensorEntity):
 class Rate(CoordinatorEntity, SensorEntity):
     """An entity using CoordinatorEntity."""
 
-    _attr_device_class = None
+    _attr_device_class = SensorDeviceClass.MONETARY
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_has_entity_name = True
     _attr_icon = "mdi:cash-multiple"
     _attr_name = "Rate"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently all historical statistics are for electric/gas rates & standing charges are lost after around 10 days.
<!--- Describe your changes in detail -->

## Motivation and Context
I want to be able to keep electric/gas rates & standing charges longer than 10 days and use a Statistics Graph to track price changes to electric/gas rates & standing charges over time.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I've had this change running on my Home Assistant instance for 15 days and long term data for rates & standing charges are shown in the Statistics Graph.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
